### PR TITLE
Server fixes

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/GameController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/GameController.java
@@ -80,6 +80,7 @@ public class GameController {
         var team = result.getValue();
         if (Boolean.TRUE.equals(isGameCompleted)) {
             webSocketService.sendMessage("/topic/game/" + id + "/gameCompleted", team.name());
+            webSocketService.sendMessage("/topic/lobby/" + id + "/end", true);
             gameService.updatePlayerStats(id, team);
         } else {
             guessDTO.setTeamColor(team.name());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/GameService.java
@@ -29,7 +29,6 @@ public class GameService {
     private final UserRepository userRepository;
     private final LobbyRepository lobbyRepository;
     private final LobbyService lobbyService;
-    private final WebsocketService websocketService;
     private final Map<Long, Object> locks = new ConcurrentHashMap<>();
 
     public GameService(
@@ -38,8 +37,7 @@ public class GameService {
             PlayerRepository playerRepository,
             UserRepository userRepository,
             LobbyRepository lobbyRepository,
-            LobbyService lobbyService,
-            WebsocketService websocketService
+            LobbyService lobbyService
     ) {
         this.wordGenerationService = wordGenerationService;
         this.gameRepository = gameRepository;
@@ -47,7 +45,6 @@ public class GameService {
         this.userRepository = userRepository;
         this.lobbyRepository = lobbyRepository;
         this.lobbyService = lobbyService;
-        this.websocketService = websocketService;
     }
 
     public void checkIfUserSpymaster(User user) {
@@ -206,8 +203,6 @@ public class GameService {
 
     private void updateLobbyAndNotifyEnd(Game game) {
         resetLobbyGameStarted(game.getId());
-
-        websocketService.sendMessage("/topic/lobby/" + game.getId() + "/end", true);
     }
 
     public void updatePlayerStats(Long id, TeamColor teamColor) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/LobbyService.java
@@ -46,6 +46,10 @@ public class LobbyService {
         if (lobbyCode != null) {
             lobby = lobbyRepository.findByLobbyCode(lobbyCode)
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lobby with code " + lobbyCode + " not found"));
+
+            if (Boolean.TRUE.equals(lobby.isGameStarted())) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Game has already started");
+            }
         }
 
         if (lobby == null) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/service/LobbyServiceTest.java
@@ -38,7 +38,22 @@ public class LobbyServiceTest {
         lobbyService = new LobbyService(lobbyRepository, playerRepository, teamRepository, websocketService);
 
         when(lobbyRepository.save(any(Lobby.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+                .thenAnswer(invocation -> {
+                    Lobby lobby = invocation.getArgument(0);
+                    if (lobby.getId() == null) {
+                        lobby.setId(1L); // oder ein Zähler für mehrere Lobbys
+                    }
+                    return lobby;
+                });
+
+        when(teamRepository.save(any(Team.class)))
+                .thenAnswer(invocation -> {
+                    Team team = invocation.getArgument(0);
+                    if (team.getId() == null) {
+                        team.setId((long) (Math.random() * 1000)); // zufällige ID oder auch fixiert
+                    }
+                    return team;
+                });
     }
 
     @Nested

--- a/websocket.doc.md
+++ b/websocket.doc.md
@@ -7,6 +7,7 @@
 | /topic/lobby/{id}/addPlayer | Player is added to lobby. | `ready: bool, color: string, role: string, playerId: long` <- Data of added player |
 | /topic/lobby/{id}/removePlayer | Player is removed from lobby. | `id: long` <- ID of removed player |
 | /topic/lobby/{id}/start | Game start. | `true` |
+| /topic/lobby/{id}/end | Game in this lobby has ended (used to reset UI or redirect to lobby page) | `true` |
 | /topic/lobby/{id}/readyError | All players are ready but not able to start game | `reason` <- string with problem |
 | /topic/lobby/{id}/playerStatus | Total and ready players in the lobby are updated | `totalPlayers: number, readyPlayers: number` <- Number of players/ ready players |
 | /topic/lobby/{id}/customWords | Custom word is added to the lobby | `customWords: List<string>` <- list with all the custom words |


### PR DESCRIPTION
	1.	WebSocket: Spielende-Benachrichtigung verlagert
	•	Die Logik zum Senden der Spielende-Benachrichtigung (/topic/lobby/{id}/end) wurde aus dem GameService entfernt und befindet sich nun im GameController.
	•	Dadurch wird die Zuständigkeit für Kommunikation und Game-State sauber getrennt.
	2.	Neuer WebSocket-Endpoint dokumentiert
	•	Neuer Eintrag für /topic/lobby/{id}/end in der WebSocket-Dokumentation hinzugefügt.

	3.	Spiel-/Lobby-Zustände verbessert
	•	Der gameStarted-Status der Lobby wird jetzt beim Spielstart korrekt gesetzt und beim Spielende zurückgesetzt.
	•	Zusätzlich werden alle ready-Status der Spieler auf false gesetzt, um eine neue Runde sauber vorzubereiten.
	4.	Lobby-Timer optimiert
	•	Während ein Spiel läuft, wird der Lobby-Timer pausiert.
	•	Beim Spielende wird Spielende-Benachrichtigung (/topic/lobby/{id}/end) via Websocket an die Lobby gesendet, wodurch der Inaktivitäts-Timer zurückgesetzt wird.
	5.	Tests angepasst
	•	Bestehende Unit-Tests wurden überarbeitet, um das neue Verhalten abzudecken.
	•	Insbesondere das Zurücksetzen des ready-Status und der gameStarted-Logik wird nun abgedeckt.